### PR TITLE
feat: Implement conversation memory

### DIFF
--- a/src/fin_engine.py
+++ b/src/fin_engine.py
@@ -50,8 +50,13 @@ Note: This is general information. Please consult with our financial advisors fo
 """
         }
 
-    def generate_response(self, query: str, context) -> str:
+    def generate_response(self, query: str, context, history: list = None) -> str:
         try:
+            # Prepend history to query if available
+            if history:
+                history_text = "\n".join([f"Previous Q: {h_query}\nPrevious A: {h_response}" for h_query, h_response in history])
+                query = f"{history_text}\n\nCurrent Q: {query}"
+
             # If we have context items
             if isinstance(context, list) and context:
                 # Check if the results come from vector search (will have 'score' field)

--- a/src/main.py
+++ b/src/main.py
@@ -2,6 +2,7 @@
 ##### src/main.py #####
 import os
 import yaml
+import uuid  # Import uuid
 os.environ["TOKENIZERS_PARALLELISM"] = "false"  # Prevent tokenizers warning
 
 from fastapi import FastAPI, HTTPException
@@ -26,18 +27,32 @@ app.add_middleware(
 with open("config.yaml", "r") as f:
     config = yaml.safe_load(f)
 
+conversation_histories = {}  # Global dictionary to store conversation histories
+
 class QueryRequest(BaseModel):
     query: str
     channel: str  # e.g., "email", "whatsapp", "chat"
     recipient: str = None  # Optional recipient (phone number or email)
+    session_id: str = None  # Optional session ID
 
 @app.post("/ask")
 def ask(query_request: QueryRequest):
+    session_id = query_request.session_id
+    if not session_id:
+        session_id = str(uuid.uuid4())  # Generate new session_id if not provided
+        conversation_histories[session_id] = []  # Initialize history for new session
+
+    history = conversation_histories.get(session_id, [])
+
     # Get relevant data from knowledge base
     relevant_data = retrieve_relevant_data(query_request.query)
     
-    # Generate response
-    response = generate_response(query_request.query, relevant_data)
+    # Generate response using history
+    response = generate_response(query_request.query, relevant_data, history)
+    
+    # Update history
+    history.append((query_request.query, response))
+    conversation_histories[session_id] = history
     
     # Handle recipient
     recipient = query_request.recipient
@@ -49,7 +64,7 @@ def ask(query_request: QueryRequest):
     # Send response to appropriate channel
     send_response_to_channel(query_request.channel, response, recipient)
     
-    return {"response": response}
+    return {"response": response, "session_id": session_id}
 
 @app.get("/")
 def root():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,97 @@
+import pytest
+from fastapi.testclient import TestClient
+from src.main import app, conversation_histories  # Import app and conversation_histories
+
+client = TestClient(app)
+
+def test_conversation_memory():
+    # Clear conversation histories for a clean test environment
+    conversation_histories.clear()
+
+    # First query
+    query1 = "What is a Roth IRA?"
+    response1 = client.post("/ask", json={"query": query1, "channel": "test"})
+    
+    assert response1.status_code == 200
+    data1 = response1.json()
+    assert "response" in data1
+    assert "session_id" in data1
+    
+    session_id = data1["session_id"]
+    response_text1 = data1["response"]
+
+    # Assert that the first response is about Roth IRA
+    assert "roth ira" in response_text1.lower()
+    assert "tax-free" in response_text1.lower() # Specific detail about Roth IRA
+
+    # Second query, dependent on the first, using the session_id
+    query2 = "What are its benefits?"
+    response2 = client.post("/ask", json={"query": query2, "channel": "test", "session_id": session_id})
+    
+    assert response2.status_code == 200
+    data2 = response2.json()
+    assert "response" in data2
+    assert data2["session_id"] == session_id  # Ensure session_id is maintained
+
+    response_text2 = data2["response"]
+
+    # Assert that the second response uses context from the first query
+    # It should mention benefits and relate to Roth IRA, not be a generic fallback.
+    # Specific keywords to look for indicating contextually aware response about Roth IRA benefits:
+    assert "benefits" in query2.lower() # Making sure the query was about benefits
+    assert "tax-free" in response_text2.lower() or "withdrawals" in response_text2.lower() or "contributions" in response_text2.lower()
+    
+    # Check that it's not a generic fallback (which might happen if context is lost)
+    assert "don't have specific information" not in response_text2.lower()
+    assert "knowledge base" not in response_text2.lower() # common in some fallbacks
+
+    # Check that the conversation history was actually stored and used
+    assert session_id in conversation_histories
+    assert len(conversation_histories[session_id]) == 2
+    assert conversation_histories[session_id][0][0] == query1
+    assert conversation_histories[session_id][0][1] == response_text1
+    assert conversation_histories[session_id][1][0] == query2
+    assert conversation_histories[session_id][1][1] == response_text2
+
+def test_new_session_if_no_id_provided():
+    # Clear conversation histories for a clean test environment
+    conversation_histories.clear()
+
+    query = "What is a 401k?"
+    response = client.post("/ask", json={"query": query, "channel": "test"})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "session_id" in data
+    new_session_id = data["session_id"]
+    assert new_session_id is not None
+    assert new_session_id in conversation_histories
+    assert len(conversation_histories[new_session_id]) == 1
+
+def test_ask_endpoint_without_session_id():
+    response = client.post("/ask", json={"query": "Hello", "channel": "test"})
+    assert response.status_code == 200
+    data = response.json()
+    assert "response" in data
+    assert "session_id" in data # Should generate a new session_id
+    assert data["session_id"] is not None
+
+def test_ask_endpoint_with_session_id():
+    session_id = "test-session-123"
+    conversation_histories[session_id] = [] # Initialize history for this session
+
+    response = client.post("/ask", json={"query": "Hello again", "channel": "test", "session_id": session_id})
+    assert response.status_code == 200
+    data = response.json()
+    assert "response" in data
+    assert data["session_id"] == session_id
+    assert len(conversation_histories[session_id]) == 1 # History should be updated
+    
+    # Clean up
+    del conversation_histories[session_id]
+
+# A simple root endpoint test to ensure TestClient is working with the app
+def test_read_root():
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.json() == {"message": "Financial AI Agent API. Use /ask endpoint to ask questions."}


### PR DESCRIPTION
This change introduces conversation memory to the Financial AI Agent.

Key changes:
- Sessions are tracked using a `session_id`. If you do not provide one, a new UUID is generated and returned.
- Conversation history (pairs of query and response) is stored in memory, associated with the `session_id`.
- The `FinancialAI.generate_response` method now accepts an optional history. If provided, the previous Q&As are prepended to the current query to give context to the language model.
- The `/ask` endpoint in `src/main.py` now manages the retrieval and storage of conversation history and includes the `session_id` in its response.
- Added unit tests for the conversation memory feature in `tests/test_main.py`, ensuring that follow-up questions are answered in the context of previous interactions.